### PR TITLE
feat: Offer S2I scripts as an alternative

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,36 @@
+#!/bin/bash
+echo "---> Adding yarn to the image"
+npm install -g yarn
+
+set -e
+
+shopt -s dotglob
+if [ -d /tmp/artifacts ] && [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
+    echo "---> Restoring previous build artifacts ..."
+    mv -T --verbose /tmp/artifacts/node_modules "${HOME}/node_modules"
+fi
+
+echo "---> Installing application source ..."
+mv /tmp/src/* ./
+
+# Fix source directory permissions
+fix-permissions ./
+echo "---> Building in production mode"
+yarn install --frozen-lockfile --network-timeout 300000
+yarn tsc
+yarn --cwd packages/backend build
+cp packages/backend/dist/skeleton.tar.gz ./
+tar xzf skeleton.tar.gz && rm skeleton.tar.gz
+
+echo "---> Clean up after build"
+yarn install --frozen-lockfile --production --network-timeout 300000
+rm -rf "$(yarn cache dir)"
+yarn cache clean
+rm -rf .cache
+
+echo "---> Copying build bundle"
+cp packages/backend/dist/bundle.tar.gz ./
+
+tar xzf bundle.tar.gz && rm bundle.tar.gz
+# Fix source directory permissions
+fix-permissions ./

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+echo "--> Running app with production configuration"
+node packages/backend --config /config/app-config.yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# backstage-autobuild
+# CI build of Backstage
+
+## Minimal Backstage instance boilerplate
+
+To get started with your own Backstage instance, follow the [Getting Started](https://backstage.io/docs/getting-started/) instructions.
+
+This repository uses a vanilla Backstage app created via following command:
+
+```bash
+echo backstage | npx @backstage/create-app
+```
+
+## Docker/Podman
+
+This repository provides a `Dockerfile` allowing you to build Backstage as a container based on [UBI9/nodejs-16 image](https://catalog.redhat.com/software/containers/ubi9/nodejs-16/61a60604c17162a20c1c6a2e):
+
+```bash
+BACKSTAGE_LOCATION=<path_to_backstage>
+IMAGE=<target_image_tag>
+
+cp ./Dockerfile ./.dockerignore $BACKSTAGE_LOCATION
+docker build -t $IMAGE $BACKSTAGE_LOCATION
+```
+
+## Source-to-Image
+
+The Backstage image can be also created via [Source-to-Image](https://github.com/openshift/source-to-image).
+
+Please install the `s2i` cli tool to build locally.
+
+### Using docker daemon
+
+```bash
+BACKSTAGE_LOCATION=<path_to_backstage>
+IMAGE=<target_image_tag>
+
+s2i build \
+  $BACKSTAGE_LOCATION \
+  --scripts-url https://raw.githubusercontent.com/redhat-developer/redhat-backstage-build/main/.s2i/bin/ \
+  registry.access.redhat.com/ubi9/nodejs-16:latest \
+  $IMAGE
+```
+
+### Using rootless podman
+
+```bash
+BACKSTAGE_LOCATION=<path_to_backstage>
+IMAGE=<target_image_tag>
+
+tmp_dir=$(mktemp -d)
+s2i build \
+  $BACKSTAGE_LOCATION \
+  --scripts-url https://raw.githubusercontent.com/redhat-developer/redhat-backstage-build/main/.s2i/bin/ \
+  registry.access.redhat.com/ubi9/nodejs-16:latest \
+  --as-dockerfile ${tmp_dir}/Containerfile
+
+cd $tmp_dir
+podman build -t $IMAGE .
+rm -rf $tmp_dir
+```
+
+### Building in OpenShift cluster
+
+Remote builds are also possible in OpenShift. S2I can be used remotely against any Backstage repository without a local Dockerfile.
+
+```bash
+GIT_REPOSITORY=<your_backstage_instance_git_repository>
+GIT_REF=<branch_or_commit>
+
+cat << EOF | oc apply -f -
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: backstage
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: backstage
+  source:
+    type: Git
+    git:
+      uri: $GIT_REPOSITORY
+      ref:  $GIT_REF
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: "nodejs:latest"
+        namespace: openshift
+      scripts: https://raw.githubusercontent.com/redhat-developer/redhat-backstage-build/main/.s2i/bin/
+  triggers:
+  - type: ConfigChange
+EOF
+```


### PR DESCRIPTION
Allow users option to use S2I. These are sample S2I scripts which work well together with ubi8/9 nodejs builder images.

Based on S2I scripts from Operate First: https://github.com/operate-first/service-catalog/tree/main/.s2i/bin

Related to: [helm-backstage#7](https://github.com/redhat-developer/helm-backstage/pull/7)